### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         env:
           # NOTE: inject the GITHUB_TOKEN for the trunk managed tflint linter
           # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
@@ -28,6 +28,6 @@ jobs:
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
-      - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
+      - uses: masterpointio/github-action-tf-test@c1e41998f67925ac3f34e0bbcfcaa4a44d1f0cd9 # v1.0.1
         with:
           tf_type: ${{ matrix.tf }}
           aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trunk Upgrade
         uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions